### PR TITLE
[WIP] Infoblox view field support

### DIFF
--- a/api/v1beta1/externaldns_types.go
+++ b/api/v1beta1/externaldns_types.go
@@ -361,6 +361,18 @@ type ExternalDNSInfobloxProviderOptions struct {
 	// +kubebuilder:validation:Required
 	// +required
 	WAPIVersion string `json:"wapiVersion"`
+
+	// view is the DNS view.
+	// If not set, no view will be sent to Infoblox WAPI
+	// which will result in the usage of the default DNS view.
+	// DNS view cannot be longer than 64 characters
+	// and can contain only printable character
+	// Source: https://docs.infoblox.com/space/NAG8/22251550/Configuring+DNS+Views#ConfiguringDNSViews-bookmark1691.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxLength=64
+	// +optional
+	View string `json:"view"`
 }
 
 // SecretReference contains the information to let you locate the desired secret.

--- a/bundle/manifests/externaldns.olm.openshift.io_externaldnses.yaml
+++ b/bundle/manifests/externaldns.olm.openshift.io_externaldnses.yaml
@@ -690,6 +690,14 @@ spec:
                       gridHost:
                         description: GridHost is the IP of the Infoblox Grid host.
                         type: string
+                      view:
+                        description: 'view is the DNS view. If not set, no view will
+                          be sent to Infoblox WAPI which will result in the usage
+                          of the default DNS view. DNS view cannot be longer than
+                          64 characters and can contain only printable character Source:
+                          https://docs.infoblox.com/space/NAG8/22251550/Configuring+DNS+Views#ConfiguringDNSViews-bookmark1691.'
+                        maxLength: 64
+                        type: string
                       wapiPort:
                         description: WAPIPort is the port for the Infoblox WAPI.
                         type: integer

--- a/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
+++ b/config/crd/bases/externaldns.olm.openshift.io_externaldnses.yaml
@@ -692,6 +692,14 @@ spec:
                       gridHost:
                         description: GridHost is the IP of the Infoblox Grid host.
                         type: string
+                      view:
+                        description: 'view is the DNS view. If not set, no view will
+                          be sent to Infoblox WAPI which will result in the usage
+                          of the default DNS view. DNS view cannot be longer than
+                          64 characters and can contain only printable character Source:
+                          https://docs.infoblox.com/space/NAG8/22251550/Configuring+DNS+Views#ConfiguringDNSViews-bookmark1691.'
+                        maxLength: 64
+                        type: string
                       wapiPort:
                         description: WAPIPort is the port for the Infoblox WAPI.
                         type: integer

--- a/pkg/operator/controller/externaldns/pod.go
+++ b/pkg/operator/controller/externaldns/pod.go
@@ -479,6 +479,10 @@ func (b *externalDNSContainerBuilder) fillInfobloxFields(container *corev1.Conta
 		args = append(args, fmt.Sprintf("--infoblox-wapi-version=%s", b.externalDNS.Spec.Provider.Infoblox.WAPIVersion))
 	}
 
+	if len(b.externalDNS.Spec.Provider.Infoblox.View) > 0 {
+		args = append(args, fmt.Sprintf("--infoblox-view=%s", b.externalDNS.Spec.Provider.Infoblox.View))
+	}
+
 	args = addTXTPrefixFlag(args)
 
 	env := []corev1.EnvVar{

--- a/pkg/operator/controller/externaldns/pod.go
+++ b/pkg/operator/controller/externaldns/pod.go
@@ -479,9 +479,8 @@ func (b *externalDNSContainerBuilder) fillInfobloxFields(container *corev1.Conta
 		args = append(args, fmt.Sprintf("--infoblox-wapi-version=%s", b.externalDNS.Spec.Provider.Infoblox.WAPIVersion))
 	}
 
-	if len(b.externalDNS.Spec.Provider.Infoblox.View) > 0 {
-		args = append(args, fmt.Sprintf("--infoblox-view=%s", b.externalDNS.Spec.Provider.Infoblox.View))
-	}
+	// Adding the DNS view.
+	args = append(args, fmt.Sprintf("--infoblox-view=%s", b.externalDNS.Spec.Provider.Infoblox.View))
 
 	args = addTXTPrefixFlag(args)
 


### PR DESCRIPTION
## Summary by Sourcery

Add support for the optional "view" field in the Infoblox ExternalDNS provider by extending the API and CRDs, passing the new flag to the deployment, and verifying it in unit tests.

New Features:
- Expose a new optional "view" field in the Infoblox provider configuration to specify the DNS view.

Enhancements:
- Append the --infoblox-view flag to the ExternalDNS container args when a view is set.

Documentation:
- Update CRD and bundle manifests to document the new view field with validation rules.

Tests:
- Add a unit test for the desired deployment spec when an Infoblox view is provided.